### PR TITLE
[FIX] The Windows version of the backtrace code is not thread safe.

### DIFF
--- a/libcomp/src/Exception.cpp
+++ b/libcomp/src/Exception.cpp
@@ -43,6 +43,7 @@
 #include <cstdlib>
 #include <exception>
 #include <iomanip>
+#include <mutex>
 #include <sstream>
 
 #include <signal.h>
@@ -73,6 +74,11 @@ Exception::Exception(const String& msg, const String& f, int l) :
     mLine(l), mFile(f), mMessage(msg)
 {
 #ifdef _WIN32
+    static std::mutex lock;
+
+    // Lock the mutex before generating the backtrace.
+    std::lock_guard<std::mutex> guard(lock);
+
     // Array to store each backtrace address.
     void *backtraceAddresses[USHRT_MAX];
 

--- a/standalone.cmake
+++ b/standalone.cmake
@@ -31,7 +31,7 @@ SET(VERSION_MAJOR 4)
 SET(VERSION_MINOR 1)
 
 # Patch version (a hotfix).
-SET(VERSION_PATCH 0)
+SET(VERSION_PATCH 1)
 
 # Codename for the version.
 SET(VERSION_CODENAME "Tiwaz (Unstable)")


### PR DESCRIPTION
Added a mutex to it.