### PR TITLE
AI and balance settings

### DIFF
--- a/libcomp/schema/serverconfig.xml
+++ b/libcomp/schema/serverconfig.xml
@@ -44,6 +44,8 @@
         <member type="bool" name="AutoCompressCurrency"/>
         <member type="bool" name="NRAStatusNull" default="true"/>
         <member type="bool" name="DeathPenaltyDisabled"/>
+        <member type="bool" name="DeadTokuseiDisabled"/>
+        <member type="float" name="DropLuckScalingCap" default="-1.0"/>
         <member type="float" name="XPBonus"/>
         <member type="float" name="ExpertiseBonus"/>
         <member type="float" name="DropRateBonus"/>
@@ -67,7 +69,13 @@
             <key type="u32"/>
             <value type="u8"/>
         </member>
-        <member type="bool" name="AggroLimit" default="true"/>
+        <member type="enum" name="AIAggroLimit">
+            <value>PLAYER_SHARED</value>
+            <value>INDEPENDENT</value>
+            <value>NONE</value>
+        </member>
+        <member type="bool" name="AICombatStagger" default="true"/>
+        <member type="bool" name="AILazyPathing" default="true"/>
         <member type="bool" name="IFramesEnabled" default="true"/>
     </object>
 </objgen>


### PR DESCRIPTION
New settings
-DeadTokuseiDisabled: Deactivates all tokusei from a dead entity (custom)
-DropLuckScalingCap: Caps drop rate boost from source luck (sorta custom since we don't know actual drop formula)
-AIAggroLimit: Limit number of entities attacking player + demon combined, limit number of entities attacking independent entities (player and demon separate) or no limit (maybe custom, could never confirm either way, defaulted to "more fair")
-AICombatStagger: Previous second function of "AggroLimit" to delay attacking based off charge complete and target knockback (not custom)
-AILazyPathing: "Restore" the original non-attempt to navigate geometry when pursuing a target allowing you to "hide", probably going to recommend people turn it off in release announcement but added/defaulted for accuracy (not custom)