### PR TITLE
Add iterators to String class, try to create SQLite3 database directory on failure

### DIFF
--- a/libcomp/CMakeLists.txt
+++ b/libcomp/CMakeLists.txt
@@ -92,6 +92,7 @@ SET(${PROJECT_NAME}_SRCS
     src/Packet.cpp
     src/PacketException.cpp
     #src/PacketScript.cpp
+    src/PlatformLinux.cpp
     src/PlatformWindows.cpp
     src/PEFile.cpp
     src/PersistentObject.cpp

--- a/libcomp/src/CString.cpp
+++ b/libcomp/src/CString.cpp
@@ -662,6 +662,38 @@ String String::Join(const std::list<String>& strings, const String& delimiter) {
                          });
 }
 
+String::iterator String::begin() { return d->mString.begin(); }
+
+String::iterator String::end() { return d->mString.end(); }
+
+String::const_iterator String::begin() const { return d->mString.cbegin(); }
+
+String::const_iterator String::end() const { return d->mString.cend(); }
+
+String::const_iterator String::cbegin() const { return d->mString.cbegin(); }
+
+String::const_iterator String::cend() const { return d->mString.cend(); }
+
+String::reverse_iterator String::rbegin() { return d->mString.rbegin(); }
+
+String::reverse_iterator String::rend() { return d->mString.rend(); }
+
+String::const_reverse_iterator String::rbegin() const {
+  return d->mString.crbegin();
+}
+
+String::const_reverse_iterator String::rend() const {
+  return d->mString.crend();
+}
+
+String::const_reverse_iterator String::crbegin() const {
+  return d->mString.crbegin();
+}
+
+String::const_reverse_iterator String::crend() const {
+  return d->mString.crend();
+}
+
 ::std::ostream& libcomp::operator<<(::std::ostream& os, const String& str) {
   return os << str.ToUtf8();
 }

--- a/libcomp/src/CString.h
+++ b/libcomp/src/CString.h
@@ -568,6 +568,98 @@ class String {
   }
 
   /**
+   * Standard iterator type returned by begin() and end()
+   */
+  using iterator = std::string::iterator;
+
+  /**
+   * Constant iterator type returned by cbegin() and cend()
+   */
+  using const_iterator = std::string::const_iterator;
+
+  /**
+   * Reverse iterator type returned by rbegin() and rend()
+   */
+  using reverse_iterator = std::string::reverse_iterator;
+
+  /**
+   * Constant reverse iterator type returned by rbegin() and rend()
+   */
+  using const_reverse_iterator = std::string::const_reverse_iterator;
+
+  /**
+   * Obtain a standard iterator pointing to the beginning of the String.
+   * @returns An iterator pointing to the beginning of the String.
+   */
+  iterator begin();
+
+  /**
+   * Obtain a standard iterator pointing to the end of the String.
+   * @returns An iterator pointing to the end of the String.
+   */
+  iterator end();
+
+  /**
+   * Obtain a const iterator pointing to the beginning of the String.
+   * @returns A const iterator pointing to the beginning of the String.
+   */
+  const_iterator begin() const;
+
+  /**
+   * Obtain a const iterator pointing to the end of the String.
+   * @returns A const iterator pointing to the end of the String.
+   */
+  const_iterator end() const;
+
+  /**
+   * Obtain a const iterator pointing to the beginning of the String.
+   * @returns A const iterator pointing to the beginning of the String.
+   */
+  const_iterator cbegin() const;
+
+  /**
+   * Obtain a const iterator pointing to the end of the String.
+   * @returns A const iterator pointing to the end of the String.
+   */
+  const_iterator cend() const;
+
+  /**
+   * Obtain a reverse iterator pointing to the end of the String.
+   * @returns A reverse iterator pointing to the end of the String.
+   */
+  reverse_iterator rbegin();
+
+  /**
+   * Obtain a reverse iterator pointing to the beginning of the String.
+   * @returns A reverse iterator pointing to the beginning of the String.
+   */
+  reverse_iterator rend();
+
+  /**
+   * Obtain a const reverse iterator pointing to the end of the String.
+   * @returns A const reverse iterator pointing to the end of the String.
+   */
+  const_reverse_iterator rbegin() const;
+
+  /**
+   * Obtain a const reverse iterator pointing to the beginning of the String.
+   * @returns A const reverse iterator pointing to the beginning of the String.
+   */
+  const_reverse_iterator rend() const;
+
+  /**
+   * Obtain a const reverse iterator pointing to the end of the String.
+   * @returns A const reverse iterator pointing to the end of the String.
+   */
+  const_reverse_iterator crbegin() const;
+
+  /**
+   * Obtain a const reverse iterator pointing to the beginning of the String.
+   * @returns A const reverse iterator pointing to the beginning of the String.
+   */
+  const_reverse_iterator crend() const;
+
+  /**
    * Get if argument errors will be reported. This will report the
    * error over the standard error stream.
    * @returns true if argument errors will be reported.

--- a/libcomp/src/PlatformLinux.cpp
+++ b/libcomp/src/PlatformLinux.cpp
@@ -1,0 +1,38 @@
+/**
+ * @file libcomp/src/PlatformLinux.cpp
+ * @ingroup libcomp
+ *
+ * @brief Linux/Unix specific utility functions.
+ *
+ * This file is part of the COMP_hack Library (libcomp).
+ *
+ * Copyright (C) 2012-2021 COMP_hack Team <compomega@tutanota.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "PlatformLinux.h"
+
+#ifndef _WIN32
+
+#include <sys/stat.h>
+#include <sys/types.h>
+
+bool libcomp::Platform::CreateDirectory(const libcomp::String &path) {
+  return mkdir(path.C(), 0770) == 0;
+}
+
+bool libcomp::Platform::IsPathSeparator(char c) { return c == '/'; }
+
+#endif  // !_WIN32

--- a/libcomp/src/PlatformLinux.h
+++ b/libcomp/src/PlatformLinux.h
@@ -27,4 +27,28 @@
 #ifndef LIBCOMP_SRC_PLATFORMLINUX_H
 #define LIBCOMP_SRC_PLATFORMLINUX_H
 
+#include "CString.h"
+
+namespace libcomp {
+
+namespace Platform {
+
+/**
+ * Create a directory at the provided location.
+ * @returns Whether the operation was successful or not.
+ * @ingroup Platform
+ */
+bool CreateDirectory(const libcomp::String &path);
+
+/**
+ * Determine whether a given character is a valid path separator.
+ * @returns Whether the provided character is a path separator.
+ * @ingroup Platform
+ */
+bool IsPathSeparator(char c);
+
+}  // namespace Platform
+
+}  // namespace libcomp
+
 #endif  // LIBCOMP_SRC_PLATFORMLINUX_H

--- a/libcomp/src/PlatformWindows.cpp
+++ b/libcomp/src/PlatformWindows.cpp
@@ -27,6 +27,7 @@
 #include "PlatformWindows.h"
 
 #ifdef _WIN32
+#include <direct.h>
 #include <windows.h>
 
 libcomp::String libcomp::Platform::GetLastErrorString() {
@@ -58,4 +59,15 @@ libcomp::String libcomp::Platform::GetLastErrorString() {
 
   return error;
 }
+
+// Ensure the windows.h CreateDirectory macro doesn't conflict
+#undef CreateDirectory
+bool libcomp::Platform::CreateDirectory(const libcomp::String &path) {
+  return _mkdir(path.C()) == 0;
+}
+
+bool libcomp::Platform::IsPathSeparator(char c) {
+  return c == '/' || c == '\\';
+}
+
 #endif  // _WIN32

--- a/libcomp/src/PlatformWindows.h
+++ b/libcomp/src/PlatformWindows.h
@@ -42,6 +42,20 @@ namespace Platform {
  */
 libcomp::String GetLastErrorString();
 
+/**
+ * Create a directory at the provided location.
+ * @returns Whether the operation was successful or not.
+ * @ingroup Platform
+ */
+bool CreateDirectory(const libcomp::String &path);
+
+/**
+ * Determine whether a given character is a valid path separator.
+ * @returns Whether the provided character is a path separator.
+ * @ingroup Platform
+ */
+bool IsPathSeparator(char c);
+
 }  // namespace Platform
 
 }  // namespace libcomp


### PR DESCRIPTION
This PR includes two commits:

    [ADD] Add iterator types and accessors to libcomp::String
    
    Add iterator types and accessors that mirror the underlying std::string
    type. This allows using STL algorithms that operate on iterators with
    the libcomp String type.

and:

    [MOD] Try to create database directory in DatabaseSQLite3::Open
    
    When sqlite3_open fails in DatabaseSQLite3::Open(), call into newly
    added platform-specific code to try to create the database file's parent
    directory and re-run sqlite3_open.
    
    This fixes the case where a user tries to run the server without
    manually creating the database directory.